### PR TITLE
Bump RxDart to 0.24.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   json_annotation: ^3.0.1
-  rxdart: ^0.23.1
+  rxdart: ^0.24.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Tested using [bluetooth](https://pub.dev/packages/esc_pos_bluetooth) (with bumped rxdart too).